### PR TITLE
Ensure formatted time is not affected by Default TimeZone

### DIFF
--- a/android/app/src/main/java/com/fabirt/podcastapp/ui/viewmodel/PodcastPlayerViewModel.kt
+++ b/android/app/src/main/java/com/fabirt/podcastapp/ui/viewmodel/PodcastPlayerViewModel.kt
@@ -122,6 +122,7 @@ class PodcastPlayerViewModel @Inject constructor(
 
     private fun formatLong(value: Long): String {
         val dateFormat = SimpleDateFormat("HH:mm:ss", Locale.getDefault())
+        dateFormat.timeZone = TimeZone.getTimeZone("GMT+0")
         return dateFormat.format(value)
     }
 


### PR DESCRIPTION
Adding this ensures it will not add one hour because of daylight savings.

For example, now it is showing 1 more hour in Spain.